### PR TITLE
Fix typo in keys README

### DIFF
--- a/keys/README.md
+++ b/keys/README.md
@@ -4,7 +4,7 @@ The key is used to sign the extension package, and the signature is verified by 
 
 This helps prevent unauthorized or malicious modifications to the extension, as any changes to the code would invalidate the signature and prevent the extension from being installed.
 
-To build the `.crx` file, both keys must be located under `./keys/` directory. To generate new keys use the followingg command:
+To build the `.crx` file, both keys must be located under `./keys/` directory. To generate new keys use the following command:
 
 ```
 openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out key.pub


### PR DESCRIPTION
## Summary
- fix a spelling mistake in keys README

## Testing
- `npm run lint` *(fails: web-ext not found, ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6852887774308322850a9cf9b0e48668